### PR TITLE
READMEのデータベース設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Things you may want to cover:
 
 
 ## usersテーブル
-|Column|Type|Options|
-|------|----|-------|
-|name|string|null: false, unique: true|
-|email|string|null: false, unique: true|
-|password|string|null: false|
-|message_id|
-|group_id|
+|Column|Type|Options|index|
+|------|----|-------|-----|
+|name|string|null: false, unique: true|◯|
+|email|string|null: false, unique: true|-|
+|password|string|null: false|-|
+|message_id|string||-|
+|group_id|string||-|
 
 ### Association
 - has_many :groups, through: :groups_users
@@ -39,11 +39,11 @@ Things you may want to cover:
 
 
 ## groupsテーブル
-|Column|Type|Options|
-|------|----|-------|
-|group_name|string|null: false, unique: true|
-|user_id|integer|null: false|
-|message_id|integer|null: false|
+|Column|Type|Options|index|
+|------|----|-------|-----|
+|group_name|string|null: false, unique: true|◯|
+|user_id|integer|null: false|-|
+|message_id|integer|null: false|-|
 
 ### Association
 - has_many :users, through: :groups_users
@@ -51,12 +51,12 @@ Things you may want to cover:
 
 
 ## messagesテーブル
-|Column|Type|Options|
-|------|----|-------|
-|body|text|
-|image|text|
-|group_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|Column|Type|Options|index|
+|------|----|-------|-----|
+|body|text||-|-|
+|image|text|-|-|
+|group_id|integer|null: false, foreign_key: true|-|
+|user_id|integer|null: false, foreign_key: true|-|
 
 ### Association
 - belongs_to :user
@@ -64,10 +64,10 @@ Things you may want to cover:
 
 
 ## groups_usersテーブル
-|Column|Type|Options|
-|------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|Column|Type|Options|index|
+|------|----|-------|-----|
+|user_id|integer|null: false, foreign_key: true|-|
+|group_id|integer|null: false, foreign_key: true|-|
 
 ### Association
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -30,25 +30,22 @@ Things you may want to cover:
 |name|string|null: false, unique: true|◯|
 |email|string|null: false, unique: true|-|
 |password|string|null: false|-|
-|message_id|string||-|
-|group_id|string||-|
 
 ### Association
 - has_many :groups, through: :groups_users
 - has_many :messages
+- has_many :groups_users
 
 
 ## groupsテーブル
 |Column|Type|Options|index|
 |------|----|-------|-----|
-|group_name|string|null: false, unique: true|◯|
-|user_id|integer|null: false|-|
-|message_id|integer|null: false|-|
+|name|string|null: false, unique: true|◯|
 
 ### Association
 - has_many :users, through: :groups_users
 - has_many :messages
-
+- has_many :groups_users
 
 ## messagesテーブル
 |Column|Type|Options|index|

--- a/README.md
+++ b/README.md
@@ -22,3 +22,53 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, unique: true|
+|email|string|null: false, unique: true|
+|password|string|null: false|
+|message_id|
+|group_id|
+
+### Association
+- has_many :groups, through: :groups_users
+- has_many :messages
+
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false, unique: true|
+|user_id|integer|null: false|
+|message_id|integer|null: false|
+
+### Association
+- has_many :users, through: :groups_users
+- has_many :messages
+
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|
+|image|text|
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
# what
chatspaceのREADMEを編集。データベースの各テーブルについて設定する。
・users,groupsは多対多の関連があるため中間テーブルを設置。
・users,groupsには検索向上のためindexを設定。
・null制約、外部キー制約を設置。

# why
chatspaceの基本構造においてユーザと投稿、グループの関係性を明確に定義しておくため
